### PR TITLE
Add Wayland support

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,158 +1,190 @@
-const { St, Gio, GObject, GLib, Shell, Clutter } = imports.gi
+import Clutter from 'gi://Clutter'
+import Gio from 'gi://Gio'
+import GLib from 'gi://GLib'
+import GObject from 'gi://GObject'
+import St from 'gi://St'
 
-const Me = imports.misc.extensionUtils.getCurrentExtension()
-const Main = imports.ui.main
-const PanelMenu = imports.ui.panelMenu
-const PopupMenu = imports.ui.popupMenu
 
-let KeyboardListMenu = GObject.registerClass(
-    class KeyboardListMenu extends PanelMenu.Button {
-        _init() {
-            super._init(0.0, "Keyboard cat defense")
+import { Extension, gettext as _ } from 'resource:///org/gnome/shell/extensions/extension.js'
 
-            // add main icon
-            let icon = new St.Icon({
-                gicon: Gio.icon_new_for_string(Me.path + "/cat.svg"),
-                style_class: 'cat-icon'
-            })
-            this.add_child(icon)
 
-            // even though we remove this item in _updateKeyboardList(), we need to add it
-            // if we don't, the dropdown menu won't open at all
-            this.menu.addMenuItem(new PopupMenu.PopupMenuItem('List of connected keyboards:'))
+import * as Main from 'resource:///org/gnome/shell/ui/main.js'
+import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js'
+import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js'
 
-            this.menu.connect('open-state-changed', (menu, open) => {
-                // when opening for the first time
-                if (open && !this.initialized) {
-                    this._updateKeyboardList()
-                    this.initialized = true
-                }
-            })
-        }
+class KeyboardListMenu extends PanelMenu.Button {
+    static {
+        GObject.registerClass(this)
+    }
+    displayEverything = false
+    constructor(path) {
+        super(0.0, "Keyboard cat defense")
 
-        /**
-         * Used to create the dropdown menu for the extensions
-         */
-        _updateKeyboardList() {
-            this.menu.removeAll()
+        // add main icon
+        let icon = new St.Icon({
+            gicon: Gio.icon_new_for_string(path + "/cat.svg"),
+            style_class: 'cat-icon'
+        })
+        this.add_child(icon)
 
-            this.menu.addMenuItem(new PopupMenu.PopupMenuItem('List of connected keyboards:'))
+        // even though we remove this item in _updateKeyboardList(), we need to add it
+        // if we don't, the dropdown menu won't open at all
+        this.menu.addMenuItem(new PopupMenu.PopupMenuItem('List of connected keyboards:'))
 
-            // Get the list of connected keyboards
-            let keyboards = this._getConnectedKeyboards()
+        this.menu.connect('open-state-changed', (menu, open) => {
+            // when opening for the first time
+            if (open && !this.initialized) {
+                this._updateKeyboardList()
+                this.initialized = true
+            }
+        })
+    }
 
+    /**
+     * Used to create the dropdown menu for the extensions
+     */
+    _updateKeyboardList() {
+        this.menu.removeAll()
+        let toggleItem = new PopupMenu.PopupSwitchMenuItem('Display every input device', this.displayEverything)
+        this.menu.addMenuItem(toggleItem)
+        toggleItem.connect('toggled', (item) => {
+            this.displayEverything = item.state
+            this._updateKeyboardList()
+        })
+
+        // Get the list of connected keyboards
+        this.menu.addMenuItem(new PopupMenu.PopupMenuItem('List of connected keyboards:'))
+        this._getConnectedKeyboards((err, keyboards) => {
+            if (err) {
+                logError(err)
+                return
+            }
             if (keyboards.length === 0) {
                 let item = new PopupMenu.PopupMenuItem('No keyboards connected')
                 item.setSensitive(false)
                 this.menu.addMenuItem(item)
-            } else {
-                keyboards.forEach((keyboard) => {
-                    let toggleItem = new PopupMenu.PopupSwitchMenuItem(keyboard.name, true) // Create a toggle button for the keyboard
+                return
+            }
+            keyboards.forEach((keyboard) => {
+                let toggleItem = new PopupMenu.PopupSwitchMenuItem(keyboard.name, true) // Create a toggle button for the keyboard
 
-                    this.menu.addMenuItem(toggleItem)
+                this.menu.addMenuItem(toggleItem)
 
-                    toggleItem.connect('toggled', (item) => {
-                        if (item.state) {
-                            this._enableKeyboard(keyboard.id)
-                        } else {
-                            this._disableKeyboard(keyboard.id)
+                toggleItem.connect('toggled', (item) => {
+                    if (item.state) {
+                        this._enableKeyboard(keyboard.id)
+                    } else {
+                        this._disableKeyboard(keyboard.id)
+                    }
+
+                    return Clutter.EVENT_STOP
+                })
+            })
+        })
+
+    }
+
+
+    /**
+     * Used to get the list of connected devices and filter for keyboards
+     * @param {function(Error, object)} callback - error and list of keyboards 
+     */
+    _getConnectedKeyboards(callback) {
+        const command = 'xinput list'
+        try {
+            let proc = Gio.Subprocess.new(
+                ['/bin/bash', '-c', command],
+                Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_PIPE
+            )
+            proc.communicate_utf8_async(null, null, (proc, res) => {
+                try {
+                    let [, stdout, stderr] = proc.communicate_utf8_finish(res)
+
+                    if (!proc.get_successful())
+                        callback(new Error(stderr))
+                    let keyboards = []
+                    let lines = stdout.toString().split('\n')
+
+                    const keyboardIdRegex = /id=(\d+)/
+
+                    // let masterKeyId
+                    for (let line of lines) {
+                        // get the master keyboard Id
+                        // if (line.includes('master keyboard')) {
+                        //     // if we detect the master key id
+                        //     if (keyboardIdRegex.exec(line)) {
+                        //         masterKeyId = keyboardIdRegex.exec(line)[1]
+                        //     }
+                        // }
+
+                        let parts = line.split('\t')
+                        if (!this.displayEverything) {
+                            if (!line.includes('slave  keyboard')) {
+                                continue
+                            }
+
+                            // make sure the name also includes the word keyboard
+                            if (!parts[0].includes('keyboard')) {
+                                continue
+                            }
                         }
 
-                        return Clutter.EVENT_STOP
-                    })
-                })
-            }
-        }
+                        // get the device ID
+                        let keyId = keyboardIdRegex.exec(line)
+                        if (keyId) {
+                            keyId = keyId[1]
 
-        /**
-         * Used to get the list of connected devices and filter for keyboards
-         * @return {Array} the list of keyboards
-         */
-        _getConnectedKeyboards() {
-            let [success, stdout, stderr] = GLib.spawn_command_line_sync('xinput list')
-            if (!success) {
-                log(`Error executing xinput list: ${stderr}`)
-                return []
-            }
-
-            let keyboards = []
-            let lines = stdout.toString().split('\n')
-
-            const keyboardIdRegex = /id=(\d+)/
-
-            // let masterKeyId
-            for (let line of lines) {
-                // get the master keyboard Id
-                // if (line.includes('master keyboard')) {
-                //     // if we detect the master key id
-                //     if (keyboardIdRegex.exec(line)) {
-                //         masterKeyId = keyboardIdRegex.exec(line)[1]
-                //     }
-                // }
-
-                if (line.includes('slave  keyboard')) {
-                    let parts = line.split('\t')
-
-                    // make sure the name also includes the word keyboard
-                    if (!parts[0].includes('keyboard')) {
-                        continue
+                            // for the keyboard name, trim the white space
+                            // and loose the first chars
+                            const keyboardName = parts[0].trim().slice(2)
+                            keyboards.push({
+                                name: keyboardName,
+                                id: keyId,
+                            })
+                        }
                     }
-
-                    // get the device ID
-                    let keyId = keyboardIdRegex.exec(line)
-                    if (keyId) {
-                        keyId = keyId[1]
-
-                        // for the keyboard name, trim the white space
-                        // and loose the first chars
-                        const keyboardName = parts[0].trim().slice(2)
-                        keyboards.push({
-                            name: keyboardName,
-                            id: keyId,
-                        })
-                    }
-
+                    callback(null, keyboards)
                 }
-            }
-
-            return keyboards
-        }
-
-        /**
-         * Disables a keyboard
-         * @param  {Number} keyboardId
-         */
-        _disableKeyboard(keyboardId) {
-            // Use xinput command to disable the keyboard with the given ID
-            let command = `xinput --disable ${keyboardId}`
-            let [success, stdout, stderr] = GLib.spawn_command_line_sync(command)
-
-            if (!success) {
-                log(`Error deactivating keyboard: ${stderr}`)
-            }
-        }
-
-        /**
-         * Enables a keyboard
-         * @param  {Number} keyboardId
-         */
-        _enableKeyboard(keyboardId) {
-            // Use xinput command to enable the keyboard with the given ID
-            let command = `xinput --enable ${keyboardId}`
-            let [success, stdout, stderr] = GLib.spawn_command_line_sync(command)
-
-            if (!success) {
-                log(`Error enabling keyboard: ${stderr}`)
-            }
+                catch (e) {
+                    callback(e)
+                }
+            })
+        } catch (e) {
+            callback(e)
         }
     }
-)
 
-let KeyboardListExtension = class KeyboardListExtension {
-    constructor() {}
+    /**
+     * Disables a keyboard
+     * @param  {number} keyboardId id of a keyboard device
+     */
+    _disableKeyboard(keyboardId) {
+        let command = `xinput --disable ${keyboardId}`
+        let success = GLib.spawn_command_line_async(command)
+        if (!success) {
+            log(`Error enabling keyboard: ${stderr}`)
+        }
+        return
+    }
 
+    /**
+     * Enables a keyboard
+     * @param  {number} keyboardId id of a keyboard device
+     */
+    _enableKeyboard(keyboardId) {
+        const command = `xinput --enable ${keyboardId}`
+        let success = GLib.spawn_command_line_async(command)
+        if (!success) {
+            log(`Error enabling keyboard: ${stderr}`)
+        }
+        return
+    }
+}
+
+
+export default class extends Extension {
     enable() {
-        this._indicator = new KeyboardListMenu()
+        this._indicator = new KeyboardListMenu(this.path)
         Main.panel.addToStatusArea('keyboard-list-menu', this._indicator, 0, 'right')
     }
 
@@ -160,8 +192,4 @@ let KeyboardListExtension = class KeyboardListExtension {
         this._indicator.destroy()
         this._indicator = null
     }
-}
-
-function init() {
-    return new KeyboardListExtension()
 }

--- a/extension.js
+++ b/extension.js
@@ -1,114 +1,285 @@
-import Clutter from 'gi://Clutter'
-import Gio from 'gi://Gio'
-import GLib from 'gi://GLib'
-import GObject from 'gi://GObject'
-import St from 'gi://St'
+import Clutter from "gi://Clutter";
+import Gio from "gi://Gio";
+import GLib from "gi://GLib";
+import GObject from "gi://GObject";
+import St from "gi://St";
 
+import { Extension } from "resource:///org/gnome/shell/extensions/extension.js";
 
-import { Extension, gettext as _ } from 'resource:///org/gnome/shell/extensions/extension.js'
+import * as Main from "resource:///org/gnome/shell/ui/main.js";
+import * as PanelMenu from "resource:///org/gnome/shell/ui/panelMenu.js";
+import * as PopupMenu from "resource:///org/gnome/shell/ui/popupMenu.js";
 
+let evtestHelperProcess = null; // We store helper script process here
 
-import * as Main from 'resource:///org/gnome/shell/ui/main.js'
-import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js'
-import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js'
+/**
+* Used to control bash script that helps spawn evtest
+*/
+function controlEvtest(command) {
+    const encoder = new TextEncoder();
+    const buffer = encoder.encode(command + "\n");
+
+    if (evtestHelperProcess) {
+        evtestHelperProcess.get_stdin_pipe().write(buffer, null);
+    }
+}
 
 class KeyboardListMenu extends PanelMenu.Button {
     static {
-        GObject.registerClass(this)
+        GObject.registerClass(this);
     }
-    displayEverything = false
+    displayEverything = false;
+    waylandMode = false;
+    x11mode = false;
+
     constructor(path) {
-        super(0.0, "Keyboard cat defense")
+        super(0.0, "Keyboard cat defense");
 
         // add main icon
-        let icon = new St.Icon({
+        const icon = new St.Icon({
             gicon: Gio.icon_new_for_string(path + "/cat.svg"),
-            style_class: 'cat-icon'
-        })
-        this.add_child(icon)
+            style_class: "cat-icon",
+        });
+        this.add_child(icon);
 
         // even though we remove this item in _updateKeyboardList(), we need to add it
         // if we don't, the dropdown menu won't open at all
-        this.menu.addMenuItem(new PopupMenu.PopupMenuItem('List of connected keyboards:'))
+        this.menu.addMenuItem(
+            new PopupMenu.PopupMenuItem("List of connected keyboards:"),
+        );
 
-        this.menu.connect('open-state-changed', (menu, open) => {
+        this.menu.connect("open-state-changed", (menu, open) => {
             // when opening for the first time
             if (open && !this.initialized) {
-                this._updateKeyboardList()
-                this.initialized = true
+                this._updateKeyboardList();
+                this.initialized = true;
             }
-        })
+        });
+    }
+
+    /**
+     * Used to spawn bash script that helps spawn evtest
+     */
+    _startEvtestHelper() {
+        const rootExecScript = `
+        while read -r cmd arg; do
+            case "$cmd" in
+                block)
+                    evtest --grab "$arg" &
+                    ;;
+                unblock)
+                    pkill -f "evtest --grab $arg"
+                    ;;
+                exit)
+                    pkill evtest
+                    exit 0
+                    ;;
+            esac
+        done
+    `;
+        evtestHelperProcess = Gio.Subprocess.new(
+            ["pkexec", "bash", "-c", rootExecScript],
+            Gio.SubprocessFlags.STDIN_PIPE |
+                Gio.SubprocessFlags.STDOUT_PIPE |
+                Gio.SubprocessFlags.STDERR_PIPE,
+        );
     }
 
     /**
      * Used to create the dropdown menu for the extensions
      */
     _updateKeyboardList() {
-        this.menu.removeAll()
-        let toggleItem = new PopupMenu.PopupSwitchMenuItem('Display every input device', this.displayEverything)
-        this.menu.addMenuItem(toggleItem)
-        toggleItem.connect('toggled', (item) => {
-            this.displayEverything = item.state
-            this._updateKeyboardList()
-        })
+        this.menu.removeAll();
+
+        const waylandToggleItem = new PopupMenu.PopupSwitchMenuItem(
+            "Search Wayland devices",
+            this.waylandMode,
+        );
+        this.menu.addMenuItem(waylandToggleItem);
+        waylandToggleItem.connect("toggled", (item) => {
+            if (item.state) {
+                this._startEvtestHelper();
+            } else {
+                if (evtestHelperProcess) {
+                    controlEvtest(`exit`); // killing all spawned evtest processes
+                    evtestHelperProcess.force_exit(); // killing helper script process
+                }
+            }
+            this.waylandMode = item.state;
+            this._updateKeyboardList();
+        });
+        const x11ToggleItem = new PopupMenu.PopupSwitchMenuItem(
+            "Search X11 devices",
+            this.x11mode,
+        );
+        this.menu.addMenuItem(x11ToggleItem);
+        x11ToggleItem.connect("toggled", (item) => {
+            this.x11mode = item.state;
+            this._updateKeyboardList();
+        });
+        const toggleItem = new PopupMenu.PopupSwitchMenuItem(
+            "Display every input device",
+            this.displayEverything,
+        );
+        this.menu.addMenuItem(toggleItem);
+        toggleItem.connect("toggled", (item) => {
+            this.displayEverything = item.state;
+            this._updateKeyboardList();
+        });
 
         // Get the list of connected keyboards
-        this.menu.addMenuItem(new PopupMenu.PopupMenuItem('List of connected keyboards:'))
-        this._getConnectedKeyboards((err, keyboards) => {
-            if (err) {
-                logError(err)
-                return
-            }
-            if (keyboards.length === 0) {
-                let item = new PopupMenu.PopupMenuItem('No keyboards connected')
-                item.setSensitive(false)
-                this.menu.addMenuItem(item)
-                return
-            }
-            keyboards.forEach((keyboard) => {
-                let toggleItem = new PopupMenu.PopupSwitchMenuItem(keyboard.name, true) // Create a toggle button for the keyboard
+        if (this.waylandMode) {
+            this._getConnectedWaylandKeyboards((err, keyboards) => {
+                if (err) {
+                    logError(err);
+                    return;
+                }
+                if (keyboards.length === 0) {
+                    const item = new PopupMenu.PopupMenuItem(
+                        "No keyboards connected",
+                    );
+                    item.setSensitive(false);
+                    this.menu.addMenuItem(item);
+                    return;
+                }
+                this.menu.addMenuItem(
+                    new PopupMenu.PopupMenuItem(
+                        "List of Wayland connected keyboards:",
+                    ),
+                );
+                keyboards.forEach((keyboard) => {
+                    const waylandKeyboardToggleItem =
+                        new PopupMenu.PopupSwitchMenuItem(keyboard.name, true); // Create a toggle button for the keyboard
+                    this.menu.addMenuItem(waylandKeyboardToggleItem);
 
-                this.menu.addMenuItem(toggleItem)
+                    waylandKeyboardToggleItem.connect("toggled", (item) => {
+                        if (item.state) {
+                            this._enableKeyboard("wayland", keyboard.id);
+                        } else {
+                            this._disableKeyboard("wayland", keyboard.id);
+                        }
 
-                toggleItem.connect('toggled', (item) => {
-                    if (item.state) {
-                        this._enableKeyboard(keyboard.id)
-                    } else {
-                        this._disableKeyboard(keyboard.id)
-                    }
+                        return Clutter.EVENT_STOP;
+                    });
+                });
+            });
+        }
+        if (this.x11mode) {
+            this.menu.addMenuItem(
+                new PopupMenu.PopupMenuItem("List of X11 connected keyboards:"),
+            );
+            this._getConnectedX11Keyboards((err, keyboards) => {
+                if (err) {
+                    logError(err);
+                    return;
+                }
+                if (keyboards.length === 0) {
+                    const item = new PopupMenu.PopupMenuItem(
+                        "No keyboards connected",
+                    );
+                    item.setSensitive(false);
+                    this.menu.addMenuItem(item);
+                    return;
+                }
+                keyboards.forEach((keyboard) => {
+                    const x11KeyboardToggleItem =
+                        new PopupMenu.PopupSwitchMenuItem(keyboard.name, true); // Create a toggle button for the keyboard
 
-                    return Clutter.EVENT_STOP
-                })
-            })
-        })
+                    this.menu.addMenuItem(x11KeyboardToggleItem);
 
+                    x11KeyboardToggleItem.connect("toggled", (item) => {
+                        if (item.state) {
+                            this._enableKeyboard("x11", keyboard.id);
+                        } else {
+                            this._disableKeyboard("x11", keyboard.id);
+                        }
+
+                        return Clutter.EVENT_STOP;
+                    });
+                });
+            });
+        }
     }
 
+    /**
+     * Used to get the list of connected Wayland devices and filter for keyboards
+     * @param {function(Error, object)} callback - error and list of keyboards
+     */
+    _getConnectedWaylandKeyboards(callback) {
+        //const command = 'pkexec libinput list-devices | grep -A1 "Device:"'
+        const command = 'libinput list-devices | grep -A1 "Device:"';
+        const keyboards = [];
+        try {
+            const proc = Gio.Subprocess.new(
+                ["pkexec", "/bin/bash", "-c", command],
+                Gio.SubprocessFlags.STDOUT_PIPE |
+                    Gio.SubprocessFlags.STDERR_PIPE,
+            );
+            proc.communicate_utf8_async(null, null, (proc, res) => {
+                try {
+                    const [, stdout, stderr] =
+                        proc.communicate_utf8_finish(res);
+
+                    if (!proc.get_successful()) callback(new Error(stderr));
+
+                    const devicesArray = stdout.split("--");
+
+                    for (const deviceStrings of devicesArray) {
+                        if (!this.displayEverything) {
+                            // make sure the name also includes the word keyboard
+                            if (
+                                !deviceStrings
+                                    .toLowerCase()
+                                    .includes("keyboard")
+                            ) {
+                                continue;
+                            }
+                        }
+                        let parts = deviceStrings.split("\n");
+                        parts = parts.filter((part) => part != ""); // removing every empty element from array
+                        const deviceName = parts[0].split(":")[1].trim();
+                        const deviceKernelPath = parts[1].split(":")[1].trim();
+                        keyboards.push({
+                            name: deviceName,
+                            id: deviceKernelPath,
+                            type: "wayland",
+                        });
+                    }
+                    callback(null, keyboards);
+                } catch (e) {
+                    callback(e);
+                }
+            });
+        } catch (e) {
+            callback(e);
+        }
+    }
 
     /**
      * Used to get the list of connected devices and filter for keyboards
-     * @param {function(Error, object)} callback - error and list of keyboards 
+     * @param {function(Error, object)} callback - error and list of keyboards
      */
-    _getConnectedKeyboards(callback) {
-        const command = 'xinput list'
+    _getConnectedX11Keyboards(callback) {
+        const command = "xinput list";
         try {
-            let proc = Gio.Subprocess.new(
-                ['/bin/bash', '-c', command],
-                Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_PIPE
-            )
+            const proc = Gio.Subprocess.new(
+                ["/bin/bash", "-c", command],
+                Gio.SubprocessFlags.STDOUT_PIPE |
+                    Gio.SubprocessFlags.STDERR_PIPE,
+            );
             proc.communicate_utf8_async(null, null, (proc, res) => {
                 try {
-                    let [, stdout, stderr] = proc.communicate_utf8_finish(res)
+                    const [, stdout, stderr] =
+                        proc.communicate_utf8_finish(res);
 
-                    if (!proc.get_successful())
-                        callback(new Error(stderr))
-                    let keyboards = []
-                    let lines = stdout.toString().split('\n')
+                    if (!proc.get_successful()) callback(new Error(stderr));
+                    const keyboards = [];
+                    const lines = stdout.toString().split("\n");
 
-                    const keyboardIdRegex = /id=(\d+)/
+                    const keyboardIdRegex = /id=(\d+)/;
 
                     // let masterKeyId
-                    for (let line of lines) {
+                    for (const line of lines) {
                         // get the master keyboard Id
                         // if (line.includes('master keyboard')) {
                         //     // if we detect the master key id
@@ -117,79 +288,98 @@ class KeyboardListMenu extends PanelMenu.Button {
                         //     }
                         // }
 
-                        let parts = line.split('\t')
+                        const parts = line.split("\t");
                         if (!this.displayEverything) {
-                            if (!line.includes('slave  keyboard')) {
-                                continue
+                            if (!line.includes("slave  keyboard")) {
+                                continue;
                             }
 
                             // make sure the name also includes the word keyboard
-                            if (!parts[0].includes('keyboard')) {
-                                continue
+                            if (!parts[0].includes("keyboard")) {
+                                continue;
                             }
                         }
 
                         // get the device ID
-                        let keyId = keyboardIdRegex.exec(line)
+                        let keyId = keyboardIdRegex.exec(line);
                         if (keyId) {
-                            keyId = keyId[1]
+                            keyId = keyId[1];
 
                             // for the keyboard name, trim the white space
                             // and loose the first chars
-                            const keyboardName = parts[0].trim().slice(2)
+                            const keyboardName = parts[0].trim().slice(2);
                             keyboards.push({
                                 name: keyboardName,
                                 id: keyId,
-                            })
+                                type: "x11",
+                            });
                         }
                     }
-                    callback(null, keyboards)
+                    callback(null, keyboards);
+                } catch (e) {
+                    callback(e);
                 }
-                catch (e) {
-                    callback(e)
-                }
-            })
+            });
         } catch (e) {
-            callback(e)
+            callback(e);
         }
     }
 
     /**
      * Disables a keyboard
+     * @param  {string} keyboardType type of keyboard device, wayland or x11
      * @param  {number} keyboardId id of a keyboard device
      */
-    _disableKeyboard(keyboardId) {
-        let command = `xinput --disable ${keyboardId}`
-        let success = GLib.spawn_command_line_async(command)
-        if (!success) {
-            log(`Error enabling keyboard: ${stderr}`)
+    _disableKeyboard(keyboardType, keyboardId) {
+        if (keyboardType === "wayland") {
+            try {
+                controlEvtest(`block ${keyboardId}`);
+            } catch (e) {
+                logError(e);
+            }
+            return;
         }
-        return
+        const command = `xinput --disable ${keyboardId}`;
+        const success = GLib.spawn_command_line_async(command);
+        if (!success) {
+            log(`Error disabling keyboard: ${stderr}`);
+        }
+        return;
     }
 
     /**
      * Enables a keyboard
+     * @param  {string} keyboardType type of keyboard device, wayland or x11
      * @param  {number} keyboardId id of a keyboard device
      */
-    _enableKeyboard(keyboardId) {
-        const command = `xinput --enable ${keyboardId}`
-        let success = GLib.spawn_command_line_async(command)
-        if (!success) {
-            log(`Error enabling keyboard: ${stderr}`)
+    _enableKeyboard(keyboardType, keyboardId) {
+        if (keyboardType === "wayland") {
+            controlEvtest(`unblock ${keyboardId}`);
+            return;
         }
-        return
+        const command = `xinput --enable ${keyboardId}`;
+        const success = GLib.spawn_command_line_async(command);
+        if (!success) {
+            log(`Error enabling keyboard: ${stderr}`);
+        }
+        return;
     }
 }
 
-
 export default class extends Extension {
     enable() {
-        this._indicator = new KeyboardListMenu(this.path)
-        Main.panel.addToStatusArea('keyboard-list-menu', this._indicator, 0, 'right')
+        this._indicator = new KeyboardListMenu(this.path);
+        Main.panel.addToStatusArea(
+            "keyboard-list-menu",
+            this._indicator,
+            0,
+            "right",
+        );
     }
 
     disable() {
-        this._indicator.destroy()
-        this._indicator = null
+        controlEvtest(`exit`);
+        this._indicator?.destroy();
+        this._indicator = null;
     }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "description": "Protect your keyboard with the most advance system. Disable the keyboard in seconds and continue using your system. The extension requires xinput as a dependency",
   "uuid": "keyboard-cat-defense@onel.github.io",
   "shell-version": [
-    "3.36", "43"
+    "3.36", "48"
   ],
   "url": "https://github.com/onel/keyboard-cat-defense",
   "version": 1

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Keyboard cat defense",
-  "description": "Protect your keyboard with the most advance system. Disable the keyboard in seconds and continue using your system. The extension requires xinput as a dependency",
+  "description": "Protect your keyboard with the most advance system. Disable the keyboard in seconds and continue using your system. The extension requires xinput and evtest as a dependency. It also requires root privileges for using in Wayland.",
   "uuid": "keyboard-cat-defense@onel.github.io",
   "shell-version": [
     "3.36", "48"


### PR DESCRIPTION
Added support for Wayland by using evtest utility. Now the extension could work both for X11 and Wayland protocols.

This is kind of a breaking change, because I based this on my last pull request where I made the code to be compatible with ECMAScript modules. I also decided to do some refactoring while I was at it. I tested this extension both in X11 and Wayland environments and they seem to be working fine for me, however this update introduces a couple of nuances:

1. This extension now requires root privileges. There is no way that I know of that allows to block input without elevated privileges on Wayland.
2. Not only does it require root privileges, but I had to make a hacky solution that keeps bash scripts with those privileges alive all the time. Seems like a unsafe way, [but I couldn't figure out a way to unblock input device without having user to enter his password into pkexec authorization window](https://discourse.gnome.org/t/how-to-kill-gio-subprocess-child-if-it-was-spawned-with-elevated-privileges-via-pkexec/33776/3). The only way it can pose a security risk that I can think of is intercepting extension's memory and send malformed input to elevated bash script.

That being said, extension still works and at least it suits my needs. I hope that someone else will also benefit from it.